### PR TITLE
Fix source files same as output file

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -31,7 +31,7 @@ commander
   .option('-d, --dir <assets folder>', 'injected assets directory, default: "./"')
   .option('-p, --pattern <string>', 'use this pattern to generate paths, default {dir}/{base}')
   .option('-w, --watch', 'run on every source file change')
-  .option('-e, --encoding <string>', 'read/write encoding, encoding "utf-8"')
+  .option('-e, --encoding <string>', 'read/write encoding, encoding "utf-8"');
 
 commander.parse(process.argv);
 
@@ -43,11 +43,6 @@ var options = Object.keys(DEFAULTS).reduce(function(options, key){
 var run = insertassets.bind(null, options);
 
 if (options.watch) {
-
-  function prefixGlobWithDir(glob){
-    return path.join(options.dir, glob);
-  };
-
   var watchedGlobs = []
     .concat(options.referenceGlobs)
     .concat(options.inlineGlobs)
@@ -59,3 +54,7 @@ if (options.watch) {
 }
 
 run();
+
+function prefixGlobWithDir(glob){
+  return path.join(options.dir, glob);
+}

--- a/test.js
+++ b/test.js
@@ -8,6 +8,10 @@ function cleanDist() {
   rimraf.sync(path.join(__dirname, 'test/dist/*.html'));
 }
 
+function copyFile(srcPath, destPath){
+  return fs.writeFileSync(path.join(__dirname, destPath), getContent(srcPath));
+}
+
 function getContent(filePath) {
   return fs.readFileSync(path.join(__dirname, filePath)).toString();
 }
@@ -20,12 +24,12 @@ var expectations = [
   'specifyDir',
   'withPattern',
 ].reduce(function(expectations, file){
-    expectations[file] = getContent('test/expectations/' + file + '.html')
+    expectations[file] = getContent('test/expectations/' + file + '.html');
     return expectations;
   }, {});
 
 tap.test('CLI', function(test){
-  test.plan(7);
+  test.plan(8);
 
   test.test('No options', function(test){
     test.plan(2);
@@ -108,6 +112,23 @@ tap.test('CLI', function(test){
     ], function(error, stdout, stderr){
       test.equal('', stderr);
       test.equal(expectations.withPattern, stdout);
+    });
+  });
+
+  test.test('-s same as -o', function(test){
+    test.plan(3);
+    cleanDist();
+    copyFile('test/src/index.html','test/dist/index.html');
+    child_process.execFile('./bin.js', [
+      '-s', 'test/dist/index.html',
+      '-o', 'test/dist/index.html'
+    ], function(error, stdout, stderr){
+      test.equal('', stderr);
+      test.equal('', stdout);
+
+      var output = getContent('test/dist/index.html');
+      cleanDist();
+      test.equal(output, expectations.noGlob);
     });
   });
 });


### PR DESCRIPTION
Resolves #1
Fixed case when the source file was the same as the output file where
opening the write stream would truncate the file before the read steam
could read it.
Added test for this scenario.
Also made the linter happy.
